### PR TITLE
chore(ci): Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
     - main
     - master
     paths:
-    - '.github/workflows/release.yml'
+    - .github/workflows/release.yml
     - '**/*.py'
     - '**/*.sh'
     - Dockerfile*


### PR DESCRIPTION
<!--
Thank you for helping to improve pre-commit-terraform!
-->

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [ ] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [x] This PR enhances existing functionality.

### Description of your changes

This PR updates the `.github/workflows/release.yml` workflow to:
- Remove the redundant top-level `permissions: contents: read` block.
- Ensure the workflow uses only job-level permissions (`contents: write`, `issues: write`, `pull-requests: write`) for the release job.
- Remove the custom `GITHUB_TOKEN` environment variable, so the default GitHub Actions token is used for semantic-release.

These changes simplify permissions management and follow GitHub Actions best practices.

<!-- Fixes # -->

### How can we test changes

- Run the release workflow on a push to `main` or `master` and verify that semantic-release can create releases and push tags using the default `GITHUB_TOKEN`.
- Confirm that no permission errors occur and that releases are