### PR TITLE
ci: Do not run Docker-based hooks on pre-commit.ci by default

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -189,6 +189,7 @@
   args: [terraform, fmt]
   files: \.(tf|tofu|tfvars|tftest\.hcl|tfmock\.hcl)$
   exclude: \.terraform/.*$
+  default: false
 
 - id: terraform_validate_docker
   name: Terraform validate (Docker)
@@ -200,6 +201,7 @@
   pass_filenames: false
   files: \.(tf|tofu|tfvars|terraform\.lock\.hcl)$
   exclude: \.terraform/.*$
+  default: false
 
 - id: terraform_tflint_docker
   name: Terraform validate with tflint (Docker)
@@ -212,6 +214,7 @@
   pass_filenames: false
   files: \.(tf|tofu|tfvars)$
   exclude: \.terraform/.*$
+  default: false
 
 - id: terraform_docs_docker
   name: Terraform docs (Docker)
@@ -224,6 +227,7 @@
   pass_filenames: false
   files: \.(tf|tofu|terraform\.lock\.hcl)$
   exclude: \.terraform/.*$
+  default: false
 
 - id: terraform_checkov_docker
   name: Checkov (Docker)
@@ -236,6 +240,7 @@
   files: \.(tf|tofu)$
   exclude: \.terraform/.*$
   require_serial: true
+  default: false
 
 - id: terraform_trivy_docker
   name: Terraform validate with trivy (Docker)
@@ -249,6 +254,7 @@
   pass_filenames: false
   files: \.(tf|tofu|tfvars)$
   exclude: \.terraform/.*$
+  default: false
 
 - id: infracost_breakdown_docker
   name: Infracost breakdown (Docker)
@@ -260,3 +266,4 @@
   require_serial: true
   files: \.(tf|tofu|tfvars|hcl)$
   exclude: \.terraform/.*$
+  default: false


### PR DESCRIPTION
<!--
Thank you for helping to improve pre-commit-terraform!
-->

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [ ] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [x] This PR enhances existing functionality.

### Description of your changes

This PR updates all Docker-based hooks in `.pre-commit-hooks.yaml` to include `default: false`. This prevents these hooks from running by default on environments like pre-commit.ci, which do not support Docker, and avoids related errors. The hooks can still be enabled locally or in CI environments where Docker is available.

<!-- Fixes # -->

### How can we test changes

- Run pre-commit locally and verify Docker-based hooks still work when enabled.
- Confirm that pre-commit.ci no longer attempts to run Docker-based hooks and does not error.
- CI workflows (e.g., GitHub Actions) should continue to run Docker-based hooks