### PR TITLE
ci: Fixing pre-commit validate hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -196,12 +196,13 @@
   name: Terraform validate (Docker)
   description: >-
     Validates all Terraform configuration files using Docker.
+    Automatically runs 'terraform init' and retries validation if provider/module errors are detected.
     NOTE: Requires Docker to be available. Use 'skip' in .pre-commit-config.yaml
     if running on pre-commit.ci or other environments without Docker.
   require_serial: true
   entry: ghcr.io/actuarysailor/pre-commit-terraform-tools:latest
   language: docker_image
-  args: [terraform, validate]
+  args: [/usr/bin/hooks/terraform_validate.sh, --hook-config=--retry-once-with-cleanup=true]
   pass_filenames: false
   files: \.(tf|tofu|tfvars|terraform\.lock\.hcl)$
   exclude: \.terraform/.*$

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -203,8 +203,12 @@
   require_serial: true
   entry: ghcr.io/actuarysailor/pre-commit-terraform-tools:sha-26e2d3a
   language: docker_image
-  args: [bash, -c, /usr/bin/hooks/terraform_validate.sh --hook-config=--retry-once-with-cleanup=true
-      --hook-config=--parallelism-ci-cpu-cores=2]
+  args: 
+    - /usr/bin/hooks/terraform_validate.sh
+    - --hook-config=--retry-once-with-cleanup=true
+    - --hook-config=--parallelism-ci-cpu-cores=2
+    - --
+    - .
   pass_filenames: false
   files: \.(tf|tofu|tfvars|terraform\.lock\.hcl)$
   exclude: \.terraform/.*$

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -203,12 +203,12 @@
   require_serial: true
   entry: ghcr.io/actuarysailor/pre-commit-terraform-tools:sha-26e2d3a
   language: docker_image
-  args: 
-    - /usr/bin/hooks/terraform_validate.sh
-    - --hook-config=--retry-once-with-cleanup=true
-    - --hook-config=--parallelism-ci-cpu-cores=2
-    - --
-    - .
+  args:
+  - /usr/bin/hooks/terraform_validate.sh
+  - --hook-config=--retry-once-with-cleanup=true
+  - --hook-config=--parallelism-ci-cpu-cores=2
+  - --
+  - .
   pass_filenames: false
   files: \.(tf|tofu|tfvars|terraform\.lock\.hcl)$
   exclude: \.terraform/.*$

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -196,7 +196,8 @@
   name: Terraform validate (Docker)
   description: >-
     Validates all Terraform configuration files using Docker.
-    Automatically runs 'terraform init' and retries validation if provider/module errors are detected.
+    Automatically runs 'terraform init' and retries validation if provider/module
+    errors are detected.
     NOTE: Requires Docker to be available. Use 'skip' in .pre-commit-config.yaml
     if running on pre-commit.ci or other environments without Docker.
   require_serial: true

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -201,7 +201,7 @@
     NOTE: Requires Docker to be available. Use 'skip' in .pre-commit-config.yaml
     if running on pre-commit.ci or other environments without Docker.
   require_serial: true
-  entry: ghcr.io/actuarysailor/pre-commit-terraform-tools:latest
+  entry: ghcr.io/actuarysailor/pre-commit-terraform-tools:sha-26e2d3a
   language: docker_image
   args: [bash, -c, /usr/bin/hooks/terraform_validate.sh --hook-config=--retry-once-with-cleanup=true
       --hook-config=--parallelism-ci-cpu-cores=2]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -203,7 +203,8 @@
   require_serial: true
   entry: ghcr.io/actuarysailor/pre-commit-terraform-tools:latest
   language: docker_image
-  args: [bash, -c, "/usr/bin/hooks/terraform_validate.sh --hook-config=--retry-once-with-cleanup=true --hook-config=--parallelism-ci-cpu-cores=2"]
+  args: [bash, -c, /usr/bin/hooks/terraform_validate.sh --hook-config=--retry-once-with-cleanup=true
+      --hook-config=--parallelism-ci-cpu-cores=2]
   pass_filenames: false
   files: \.(tf|tofu|tfvars|terraform\.lock\.hcl)$
   exclude: \.terraform/.*$

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -203,7 +203,7 @@
   require_serial: true
   entry: ghcr.io/actuarysailor/pre-commit-terraform-tools:latest
   language: docker_image
-  args: [bash, -c, "/usr/bin/hooks/terraform_validate.sh --hook-config=--retry-once-with-cleanup=true"]
+  args: [bash, -c, /usr/bin/hooks/terraform_validate.sh --hook-config=--retry-once-with-cleanup=true]
   pass_filenames: false
   files: \.(tf|tofu|tfvars|terraform\.lock\.hcl)$
   exclude: \.terraform/.*$

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -203,7 +203,7 @@
   require_serial: true
   entry: ghcr.io/actuarysailor/pre-commit-terraform-tools:latest
   language: docker_image
-  args: [/usr/bin/hooks/terraform_validate.sh, --hook-config=--retry-once-with-cleanup=true]
+  args: [bash, -c, "/usr/bin/hooks/terraform_validate.sh --hook-config=--retry-once-with-cleanup=true"]
   pass_filenames: false
   files: \.(tf|tofu|tfvars|terraform\.lock\.hcl)$
   exclude: \.terraform/.*$

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -203,7 +203,7 @@
   require_serial: true
   entry: ghcr.io/actuarysailor/pre-commit-terraform-tools:latest
   language: docker_image
-  args: [bash, -c, /usr/bin/hooks/terraform_validate.sh --hook-config=--retry-once-with-cleanup=true]
+  args: [bash, -c, "/usr/bin/hooks/terraform_validate.sh --hook-config=--retry-once-with-cleanup=true --hook-config=--parallelism-ci-cpu-cores=2"]
   pass_filenames: false
   files: \.(tf|tofu|tfvars|terraform\.lock\.hcl)$
   exclude: \.terraform/.*$

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -201,7 +201,7 @@
     NOTE: Requires Docker to be available. Use 'skip' in .pre-commit-config.yaml
     if running on pre-commit.ci or other environments without Docker.
   require_serial: true
-  entry: ghcr.io/actuarysailor/pre-commit-terraform-tools:sha-26e2d3a
+  entry: ghcr.io/actuarysailor/pre-commit-terraform-tools:latest
   language: docker_image
   args:
   - /usr/bin/hooks/terraform_validate.sh

--- a/examples/.pre-commit-config-docker.yaml
+++ b/examples/.pre-commit-config-docker.yaml
@@ -3,14 +3,14 @@
 
 # Skip Docker hooks on pre-commit.ci (which doesn't support Docker)
 ci:
-  skip: 
-    - terraform_fmt_docker
-    - terraform_validate_docker
-    - terraform_tflint_docker
-    - terraform_docs_docker
-    - terraform_checkov_docker
-    - terraform_trivy_docker
-    - infracost_breakdown_docker
+  skip:
+  - terraform_fmt_docker
+  - terraform_validate_docker
+  - terraform_tflint_docker
+  - terraform_docs_docker
+  - terraform_checkov_docker
+  - terraform_trivy_docker
+  - infracost_breakdown_docker
 
 repos:
 - repo: https://github.com/actuarysailor/pre-commit-terraform

--- a/examples/.pre-commit-config-docker.yaml
+++ b/examples/.pre-commit-config-docker.yaml
@@ -3,9 +3,15 @@
 
 # Skip Docker hooks on pre-commit.ci (which doesn't support Docker)
 ci:
-  skip: [terraform_fmt_docker, terraform_validate_docker, terraform_tflint_docker,
-    terraform_docs_docker, terraform_checkov_docker, terraform_trivy_docker,
-    infracost_breakdown_docker]
+  skip: [
+    terraform_fmt_docker,
+    terraform_validate_docker,
+    terraform_tflint_docker,
+    terraform_docs_docker,
+    terraform_checkov_docker,
+    terraform_trivy_docker,
+    infracost_breakdown_docker
+  ]
 
 repos:
 - repo: https://github.com/actuarysailor/pre-commit-terraform

--- a/examples/.pre-commit-config-docker.yaml
+++ b/examples/.pre-commit-config-docker.yaml
@@ -3,15 +3,9 @@
 
 # Skip Docker hooks on pre-commit.ci (which doesn't support Docker)
 ci:
-  skip: [
-    terraform_fmt_docker,
-    terraform_validate_docker,
-    terraform_tflint_docker,
-    terraform_docs_docker,
-    terraform_checkov_docker,
-    terraform_trivy_docker,
-    infracost_breakdown_docker
-  ]
+  skip: [terraform_fmt_docker, terraform_validate_docker, terraform_tflint_docker,
+    terraform_docs_docker, terraform_checkov_docker, terraform_trivy_docker,
+    infracost_breakdown_docker]
 
 repos:
 - repo: https://github.com/actuarysailor/pre-commit-terraform

--- a/examples/.pre-commit-config-docker.yaml
+++ b/examples/.pre-commit-config-docker.yaml
@@ -3,9 +3,14 @@
 
 # Skip Docker hooks on pre-commit.ci (which doesn't support Docker)
 ci:
-  skip: [terraform_fmt_docker, terraform_validate_docker, terraform_tflint_docker,
-    terraform_docs_docker, terraform_checkov_docker, terraform_trivy_docker,
-    infracost_breakdown_docker]
+  skip: 
+    - terraform_fmt_docker
+    - terraform_validate_docker
+    - terraform_tflint_docker
+    - terraform_docs_docker
+    - terraform_checkov_docker
+    - terraform_trivy_docker
+    - infracost_breakdown_docker
 
 repos:
 - repo: https://github.com/actuarysailor/pre-commit-terraform


### PR DESCRIPTION
<!--
Thank you for helping to improve pre-commit-terraform!
-->

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [x] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [x] This PR enhances existing functionality.

### Description of your changes

This PR fixes the `terraform_validate_docker` hook to properly handle missing providers and modules by implementing automatic retry logic with `terraform init`.

**Problem**: The `terraform_validate_docker` hook was previously configured to run `terraform validate` directly, without the retry logic present in the script-based `terraform_validate` hook. As a result, if validation failed due to missing providers or uninitialized modules, the Docker hook would fail immediately instead of attempting to run `terraform init` and retry.

**Solution**: The hook is now configured to:
- Use the `/usr/bin/hooks/terraform_validate.sh` script (already present in the Docker image) instead of calling `terraform validate` directly.
- Enable `--retry-once-with-cleanup=true` by default to automatically handle missing provider/module scenarios.
- Provide the same retry logic as the script-based hook:
  - First attempt `terraform validate`
  - If it fails, run `terraform init` and retry
  - If specific error patterns are detected, clean up `.terraform/modules` and `.terraform/providers` directories and retry once more

This ensures feature parity between the script-based and Docker-based validation hooks, providing a consistent user experience regardless of which version is used.

<!-- Fixes # -->

### How can we test changes

1. **Test with missing providers**:
   - Create a Terraform configuration that references providers not yet downloaded.
   - Remove any existing `.terraform` directory.
   - Run the `terraform_validate_docker` hook and verify it automatically runs `terraform init` and succeeds.

2. **Test retry logic with corrupted state**:
   - Create a scenario with partially corrupted `.terraform/providers` or `.terraform/modules`.
   - Verify the hook detects the issue, cleans up, re-initializes, and retries validation.

3. **Compare with script-based hook**:
   - Run the same test scenarios with both `terraform_validate` and `terraform_validate_docker` hooks.
   - Verify both hooks handle missing providers/modules scenarios identically.

4. **Test in CI/CD environments**:
   - Verify the Docker hook works correctly in GitHub Actions or other CI environments where Docker is available.
   - Confirm the hook can be properly skipped in environments without Docker (like pre-commit.ci) using the `ci: